### PR TITLE
Fix test regexp for images

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = {
 
             // IMAGES
             {
-                test: /\.(jpe*g|png|gif)$/,
+                test: /\.(jpe?g|png|gif)$/,
                 loader: 'file-loader',
                 options: {
                     name: '[path][name].[ext]'


### PR DESCRIPTION
Modify the test regexp for images so that it will not match 'jpeeg', 'jpeeeg', etc.