### PR TITLE
Changed mv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you don’t want to work with lodash, just remove it from the node packages a
 ## Download
 Download in current directory
 ```sh
-$ curl -L -o master.zip https://github.com/cvgellhorn/webpack-boilerplate/archive/master.zip && unzip master.zip && rm master.zip && mv ./webpack-boilerplate-master/{.,}* ./ && rm -r ./webpack-boilerplate-master
+$ curl -L -o master.zip https://github.com/cvgellhorn/webpack-boilerplate/archive/master.zip && unzip master.zip && rm master.zip && mv ./webpack-boilerplate-master/* ./ && rm -r ./webpack-boilerplate-master
 ```
 
 ## Setup


### PR DESCRIPTION
In the previous version I was getting an error
`mv: cannot move './webpack-boilerplate-master/.' to a subdirectory of itself, './.'`
`mv: cannot move './webpack-boilerplate-master/..' to a subdirectory of itself, './..`

Now it moves only inner files