### PR TITLE
Improve download command in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you don’t want to work with lodash, just remove it from the node packages a
 ## Download
 Download in current directory
 ```sh
-$ curl -L -o master.zip https://github.com/cvgellhorn/webpack-boilerplate/archive/master.zip && unzip master.zip && rm master.zip && mv ./webpack-boilerplate-master/{.,}* ./ && rm -r ./webpack-boilerplate-master
+$ curl -L -o master.zip https://github.com/cvgellhorn/webpack-boilerplate/archive/master.zip && unzip master.zip && rm master.zip && mv ./webpack-boilerplate-master/{.[!.],}* ./ && rm -r ./webpack-boilerplate-master
 ```
 
 ## Setup


### PR DESCRIPTION
The current command does not fully execute as the part `mv ./webpack-boilerplate-master/{.,}* ./` causes an error whilst trying to move the `..` directory, hence the last `rm` command does not execute. Thanks to [this](https://stackoverflow.com/a/27963040/295687) solution on Stackoverflow, it works now.